### PR TITLE
Fixed domainFixup() causing PHP Notice

### DIFF
--- a/PiwikTracker.php
+++ b/PiwikTracker.php
@@ -443,14 +443,16 @@ class PiwikTracker
      */
     static protected function domainFixup($domain)
     {
-        $dl = strlen($domain) - 1;
-        // remove trailing '.'
-        if ($domain{$dl} === '.') {
-            $domain = substr($domain, 0, $dl);
-        }
-        // remove leading '*'
-        if (substr($domain, 0, 2) === '*.') {
-            $domain = substr($domain, 1);
+        if (strlen($domain) > 0) {
+            $dl = strlen($domain) - 1;
+            // remove trailing '.'
+            if ($domain{$dl} === '.') {
+                $domain = substr($domain, 0, $dl);
+            }
+            // remove leading '*'
+            if (substr($domain, 0, 2) === '*.') {
+                $domain = substr($domain, 1);
+            }
         }
         return $domain;
     }


### PR DESCRIPTION
Fixed a small notice in domainFixup(...) getting thrown when the cookie domain is empty/default:

```PHP Notice:  Uninitialized string offset: -1 in .../PiwikTracker.php on line 449```

Solution: Before checking the char at length - 1, check if length is greater than 0