### PR TITLE
Fixes deleteCookie() method

### DIFF
--- a/PiwikTracker.php
+++ b/PiwikTracker.php
@@ -1239,10 +1239,9 @@ class PiwikTracker
      */
     public function deleteCookies()
     {
-        $expire = $this->currentTs - 86400;
         $cookies = array('id', 'ses', 'cvar', 'ref');
         foreach ($cookies as $cookie) {
-            $this->setCookie($cookie, '', $expire);
+            $this->setCookie($cookie, '', -86400);
         }
     }
 


### PR DESCRIPTION
`setCookie()` accepts the TTL as parameter not a timestamp, so use a negative TTL to remove the cookies.

fixes #9