### PR TITLE
New const for number of max categories

### DIFF
--- a/PiwikTracker.php
+++ b/PiwikTracker.php
@@ -70,6 +70,12 @@ class PiwikTracker
     const CVAR_INDEX_ECOMMERCE_ITEM_NAME = 4;
     const CVAR_INDEX_ECOMMERCE_ITEM_CATEGORY = 5;
 
+    /**
+     * Defines how many categories can be used max when calling addEcommerceItem().
+     * @var int
+     */
+    const MAX_NUM_ECOMMERCE_ITEM_CATEGORIES = 5;
+
     const DEFAULT_COOKIE_PATH = '/';
 
     /**


### PR DESCRIPTION
See comment in addEcommerceItem(). It would be good to have a constant for this so users don't need to hardcode and limit to 5 manually.