### PR TITLE
Add method to check if Piwik URL is correct

### DIFF
--- a/PiwikTracker.php
+++ b/PiwikTracker.php
@@ -1498,6 +1498,21 @@ class PiwikTracker
     static public $DEBUG_LAST_REQUESTED_URL = false;
 
     /**
+     * Sends a simple request to the Piwik tracking API to test whether the configured Piwik URL is valid.
+     * It won't actually track any data, only test whether the configured tracking URL looks valid.
+     *
+     * @return bool
+     */
+    public function ping()
+    {
+        // we only use the base url to make sure to not track any data when this method is called.
+        $url = $this->getBaseUrl();
+        $response = $this->sendRequest($url);
+
+        return strpos(strtolower($response), 'piwik') !== false;
+    }
+
+    /**
      * @ignore
      */
     protected function sendRequest($url, $method = 'GET', $data = null, $force = false)


### PR DESCRIPTION
Happy to change the name, used ping similar to eg https://redis.io/commands/ping . We could maybe also rename it to eg `testUrl()` or `verifyUrl()` as `ping()` is confusing with `doPing()`. There are many ways that can be used for it. 

Ideally we would check for response code instead of checking for word "piwik" but the method `sendRequest` does not return the response code.

Ideally, it would also test whether the configured idSite actually exists but so far I have not figured out how to do it without changing Piwik. eg "https://demo.piwik.org/piwik.php?idsite=9999&rec=1" would return an error and we could be sure the idSite does not exist, but it is recording an actual request. "https://demo.piwik.org/piwik.php?idsite=9999&rec=0" always returns a valid image with HTTP 200 so we cannot test whether the site exists. Any ideas?