### PR TITLE
Allow arrays to be used in custom parameters

### DIFF
--- a/PiwikTracker.php
+++ b/PiwikTracker.php
@@ -1652,9 +1652,7 @@ class PiwikTracker
 
         $customFields = '';
         if (!empty($this->customParameters)) {
-            foreach ($this->customParameters as $parameter => $value) {
-                $customFields .= '&' . urlencode($parameter) . '=' . urlencode($value);
-            }
+            $customFields = '&' . http_build_query($this->customParameters, '', '&');
         }
 
         $url = $this->getBaseUrl() .


### PR DESCRIPTION
I was setting an array as value in a custom parameter but then the tracker fails because urlencode expects a string. I think http_build_query will be also better in general and handle pretty much all cases.