### PR TITLE
Get correct URL for all cases

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -2324,16 +2324,14 @@ didn't change any existing VisitorId value */
     protected static function getCurrentScriptName(): string
     {
         $url = '';
-        if (!empty($_SERVER['PATH_INFO'])) {
-            $url = $_SERVER['PATH_INFO'];
-        } else {
-            if (!empty($_SERVER['REQUEST_URI'])) {
-                if (($pos = strpos($_SERVER['REQUEST_URI'], '?')) !== false) {
-                    $url = substr($_SERVER['REQUEST_URI'], 0, $pos);
-                } else {
-                    $url = $_SERVER['REQUEST_URI'];
-                }
+        if (!empty($_SERVER['REQUEST_URI'])) {
+            if (($pos = strpos($_SERVER['REQUEST_URI'], '?')) !== false) {
+                $url = substr($_SERVER['REQUEST_URI'], 0, $pos);
+            } else {
+                $url = $_SERVER['REQUEST_URI'];
             }
+        } elseif (!empty($_SERVER['PATH_INFO'])) {
+            $url = $_SERVER['PATH_INFO'];
         }
         if (empty($url) && isset($_SERVER['SCRIPT_NAME'])) {
             $url = $_SERVER['SCRIPT_NAME'];


### PR DESCRIPTION
### Description

I noticed that the URL is not correctly found out in all cases.

Example URL: https://example.com/dir1/test

In this example, "dir1" is a real existing directory on the server, and "test" is a additional string appended and handled by the index.php script in this dir (via Apache rewrite). In this case, the MatomoTracker will track "/test" instead of "/dir1/test". This change fixes the behavior to correctly track "/dir1/test".

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [NA] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
