### PR TITLE
Fix: Not possible to create multiple Piwik tracker instances having different API urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This is the Developer Changelog for Matomo PHP Tracker. All breaking changes or 
 ### Changed
 - a lot of arguments of `MatomoTracker` methods have explicitly types
 - a lot of `MatomoTracker` method return types have strict types
+- static `$URL` is deprecated
+
+### Added
+- new private property `apiUrl` for storing API URL
 
 ## Matomo PHP Tracker 3.3.1
 ### Fixed

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -28,6 +28,7 @@ class MatomoTracker
      * MatomoTracker::$URL = 'http://yourwebsite.org/matomo/';
      *
      * @var string
+     * @deprecated
      */
     static public $URL = '';
 
@@ -202,6 +203,8 @@ class MatomoTracker
 
     private $requestMethod = null;
 
+    private string $apiUrl = '';
+
     /**
      * Builds a MatomoTracker object, used to track visits, pages and Goal conversions
      * for a specific website, by using the Matomo Tracking API.
@@ -227,6 +230,7 @@ class MatomoTracker
         );
         if (!empty($apiUrl)) {
             self::$URL = $apiUrl;
+            $this->apiUrl = $apiUrl;
         }
 
         $this->setNewVisitorId();
@@ -240,6 +244,7 @@ class MatomoTracker
     public function setApiUrl(string $url): void
     {
         self::$URL = $url;
+        $this->apiUrl = $url;
     }
 
     /**
@@ -2152,23 +2157,26 @@ didn't change any existing VisitorId value */
 
     /**
      * Returns the base URL for the Matomo server.
+     *
+     * @throws Exception
      */
     protected function getBaseUrl(): string
     {
-        if (empty(self::$URL)) {
+        if ($this->apiUrl === '') {
             throw new Exception(
                 'You must first set the Matomo Tracker URL by calling
                  MatomoTracker::$URL = \'http://your-website.org/matomo/\';'
             );
         }
-        if (strpos(self::$URL, '/matomo.php') === false
-            && strpos(self::$URL, '/proxy-matomo.php') === false
+
+        if (str_contains($this->apiUrl, '/matomo.php') === false
+            && str_contains($this->apiUrl, '/proxy-matomo.php') === false
         ) {
-            self::$URL = rtrim(self::$URL, '/');
-            self::$URL .= '/matomo.php';
+            $this->apiUrl = rtrim($this->apiUrl, '/');
+            $this->apiUrl .= '/matomo.php';
         }
 
-        return self::$URL;
+        return $this->apiUrl;
     }
 
     /**

--- a/tests/Unit/MatomoTrackerTest.php
+++ b/tests/Unit/MatomoTrackerTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Unit;
 
+use MatomoTracker;
 use PHPUnit\Framework\TestCase;
 
 class MatomoTrackerTest extends TestCase
@@ -32,7 +33,7 @@ class MatomoTrackerTest extends TestCase
         $cookieName = '_pk_id_1_f609';
         $_COOKIE[$cookieName] = $testVisitorId . '.' . $createTs;
 
-        $tracker = new \MatomoTracker(1, $apiUrl = self::TEST_URL);
+        $tracker = new MatomoTracker(1, self::TEST_URL);
         $tracker->setUrl('http://somesite.com');
         $url = $tracker->getUrlTrackPageView('test title');
         $url = preg_replace('/&r=\d+/', "", $url);
@@ -60,7 +61,7 @@ class MatomoTrackerTest extends TestCase
         $cookieName = '_pk_id_1_f609';
         $_COOKIE[$cookieName] = $testVisitorId . '.' . $createTs . '.5.' . $currentTs . '.' . $lastVisitTs . '.' . $ecommerceLastOrderTs;
 
-        $tracker = new \MatomoTracker(1, $apiUrl = self::TEST_URL);
+        $tracker = new MatomoTracker(1, self::TEST_URL);
         $tracker->setUrl('http://somesite.com');
         $url = $tracker->getUrlTrackPageView('test title');
         $url = preg_replace('/&r=\d+/', "", $url);
@@ -78,8 +79,17 @@ class MatomoTrackerTest extends TestCase
     public function test_setApiUrl()
     {
         $newApiUrl = 'https://NEW-API-URL.com';
-        $tracker = new \MatomoTracker(1, self::TEST_URL);
+        $tracker = new MatomoTracker(1, self::TEST_URL);
         $tracker->setApiUrl($newApiUrl);
+        $url = $tracker->getUrlTrackPageView('test title');
+
+        $this->assertSame(substr($url, 0, strlen($newApiUrl)), $newApiUrl);
+    }
+
+    public function testUsageApiUrl(): void
+    {
+        $newApiUrl = 'https://NEW-API-URL.com';
+        $tracker = new MatomoTracker(1, $newApiUrl);
         $url = $tracker->getUrlTrackPageView('test title');
 
         $this->assertSame(substr($url, 0, strlen($newApiUrl)), $newApiUrl);


### PR DESCRIPTION
### Description

This is a fix for https://github.com/matomo-org/matomo-php-tracker/issues/14

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
