### PR TITLE
Fix: Not possible to create multiple Piwik tracker instances having different API urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This is the Developer Changelog for Matomo PHP Tracker. All breaking changes or new features are listed below.
 
+## Matomo PHP Tracker 3.3.2
+### Changed
+- Support for formFactors client hint parameter, supported as of Matomo 5.2.0
+
 ## Matomo PHP Tracker 3.3.1
 ### Fixed
 - closed curl connection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This is the Developer Changelog for Matomo PHP Tracker. All breaking changes or new features are listed below.
 
+## Matomo PHP Tracker 3.4.0
+### Changed
+- static `$URL` is deprecated
+
+### Added
+- new private property `apiUrl` for storing API URL
+
 ## Matomo PHP Tracker 3.3.2
 ### Changed
 - Support for formFactors client hint parameter, supported as of Matomo 5.2.0

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -2098,20 +2098,24 @@ didn't change any existing VisitorId value */
      */
     protected function getBaseUrl()
     {
-        if ($this->apiUrl === '') {
+        $apiUrl = $this->apiUrl === ''
+            ? self::$URL
+            : $this->apiUrl;
+
+        if ($apiUrl === '') {
             throw new Exception(
                 'You must first set the Matomo Tracker URL by calling
                  MatomoTracker::$URL = \'http://your-website.org/matomo/\';'
             );
         }
-        if (strpos($this->apiUrl, '/matomo.php') === false
-            && strpos($this->apiUrl, '/proxy-matomo.php') === false
+        if (strpos($apiUrl, '/matomo.php') === false
+            && strpos($apiUrl, '/proxy-matomo.php') === false
         ) {
-            $this->apiUrl = rtrim($this->apiUrl, '/');
-            $this->apiUrl .= '/matomo.php';
+            $apiUrl = rtrim($apiUrl, '/');
+            $apiUrl .= '/matomo.php';
         }
 
-        return $this->apiUrl;
+        return $apiUrl;
     }
 
     /**

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -28,6 +28,7 @@ class MatomoTracker
      * MatomoTracker::$URL = 'http://yourwebsite.org/matomo/';
      *
      * @var string
+     * @deprecated
      */
     static public $URL = '';
 
@@ -202,6 +203,8 @@ class MatomoTracker
 
     private $requestMethod = null;
 
+    private $apiUrl = '';
+
     /**
      * Builds a MatomoTracker object, used to track visits, pages and Goal conversions
      * for a specific website, by using the Matomo Tracking API.
@@ -228,6 +231,7 @@ class MatomoTracker
         );
         if (!empty($apiUrl)) {
             self::$URL = $apiUrl;
+            $this->apiUrl = $apiUrl;
         }
 
         $this->setNewVisitorId();
@@ -241,6 +245,7 @@ class MatomoTracker
     public function setApiUrl(string $url)
     {
         self::$URL = $url;
+        $this->apiUrl = $url;
     }
 
     /**
@@ -2088,23 +2093,25 @@ didn't change any existing VisitorId value */
 
     /**
      * Returns the base URL for the Matomo server.
+     *
+     * @throws Exception
      */
     protected function getBaseUrl()
     {
-        if (empty(self::$URL)) {
+        if ($this->apiUrl === '') {
             throw new Exception(
                 'You must first set the Matomo Tracker URL by calling
                  MatomoTracker::$URL = \'http://your-website.org/matomo/\';'
             );
         }
-        if (strpos(self::$URL, '/matomo.php') === false
-            && strpos(self::$URL, '/proxy-matomo.php') === false
+        if (strpos($this->apiUrl, '/matomo.php') === false
+            && strpos($this->apiUrl, '/proxy-matomo.php') === false
         ) {
-            self::$URL = rtrim(self::$URL, '/');
-            self::$URL .= '/matomo.php';
+            $this->apiUrl = rtrim($this->apiUrl, '/');
+            $this->apiUrl .= '/matomo.php';
         }
 
-        return self::$URL;
+        return $this->apiUrl;
     }
 
     /**

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -223,7 +223,8 @@ class MatomoTracker
             !empty($_SERVER['HTTP_SEC_CH_UA_PLATFORM']) ? $_SERVER['HTTP_SEC_CH_UA_PLATFORM'] : '',
             !empty($_SERVER['HTTP_SEC_CH_UA_PLATFORM_VERSION']) ? $_SERVER['HTTP_SEC_CH_UA_PLATFORM_VERSION'] : '',
             !empty($_SERVER['HTTP_SEC_CH_UA_FULL_VERSION_LIST']) ? $_SERVER['HTTP_SEC_CH_UA_FULL_VERSION_LIST'] : '',
-            !empty($_SERVER['HTTP_SEC_CH_UA_FULL_VERSION']) ? $_SERVER['HTTP_SEC_CH_UA_FULL_VERSION'] : ''
+            !empty($_SERVER['HTTP_SEC_CH_UA_FULL_VERSION']) ? $_SERVER['HTTP_SEC_CH_UA_FULL_VERSION'] : '',
+            !empty($_SERVER['HTTP_SEC_CH_UA_FORM_FACTORS']) ? $_SERVER['HTTP_SEC_CH_UA_FORM_FACTORS'] : ''
         );
         if (!empty($apiUrl)) {
             self::$URL = $apiUrl;
@@ -574,10 +575,12 @@ class MatomoTracker
      *                                      all brands with the structure
      *                                      [['brand' => 'Chrome', 'version' => '10.0.2'], ['brand' => '...]
      * @param string $uaFullVersion  Value of the header 'HTTP_SEC_CH_UA_FULL_VERSION'
+     * @param string|array<string> $formFactors  Value of the header 'HTTP_SEC_CH_UA_FORM_FACTORS'
+     *      or an array containing all form factors with structure ["Desktop", "XR"]
      *
      * @return $this
      */
-    public function setClientHints($model = '', $platform = '', $platformVersion = '', $fullVersionList = '', $uaFullVersion = '')
+    public function setClientHints($model = '', $platform = '', $platformVersion = '', $fullVersionList = '', $uaFullVersion = '', $formFactors = '')
     {
         if (is_string($fullVersionList)) {
             $reg  = '/^"([^"]+)"; ?v="([^"]+)"(?:, )?/';
@@ -593,12 +596,25 @@ class MatomoTracker
             $fullVersionList = [];
         }
 
+        if (is_string($formFactors)) {
+            $formFactors = explode(',', $formFactors);
+            $formFactors = array_filter(array_map(
+                function ($item) {
+                    return trim($item, '" ');
+                },
+                $formFactors
+            ));
+        } elseif (!is_array($formFactors)) {
+            $formFactors = [];
+        }
+
         $this->clientHints = array_filter([
             'model' => $model,
             'platform' => $platform,
             'platformVersion' => $platformVersion,
             'uaFullVersion' => $uaFullVersion,
             'fullVersionList' => $fullVersionList,
+            'formFactors' => $formFactors,
         ]);
 
         return $this;
@@ -777,7 +793,7 @@ class MatomoTracker
 
         return $this->sendRequest($url);
     }
-			 
+
     /**
      * Override PageView id for every use of `doTrackPageView()`. Do not use this if you call `doTrackPageView()`
      * multiple times during tracking (if, for example, you are tracking a single page application).
@@ -2021,7 +2037,7 @@ didn't change any existing VisitorId value */
             curl_setopt_array($ch, $options);
             ob_start();
             $response = @curl_exec($ch);
-            
+
             try {
                 $header = '';
 

--- a/tests/Unit/MatomoTrackerTest.php
+++ b/tests/Unit/MatomoTrackerTest.php
@@ -84,4 +84,13 @@ class MatomoTrackerTest extends TestCase
 
         $this->assertSame(substr($url, 0, strlen($newApiUrl)), $newApiUrl);
     }
+
+    public function testUsageApiUrl(): void
+    {
+        $newApiUrl = 'https://NEW-API-URL.com';
+        $tracker = new \MatomoTracker(1, $newApiUrl);
+        $url = $tracker->getUrlTrackPageView('test title');
+
+        $this->assertSame(substr($url, 0, strlen($newApiUrl)), $newApiUrl);
+    }
 }


### PR DESCRIPTION
### Description

Fix for the issue https://github.com/matomo-org/matomo-php-tracker/issues/14

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
