### PR TITLE
Conditionally close the curl handle

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -2141,7 +2141,11 @@ didn't change any existing VisitorId value */
 
                 $this->parseIncomingCookies(explode("\r\n", $header));
             } finally {
-                curl_close($ch);
+                // curl_close has no effect since PHP 8.0
+                if (PHP_VERSION_ID < 80000) {
+                    curl_close($ch);
+                }
+
                 ob_end_clean();
             }
         } elseif (function_exists('stream_context_create')) {


### PR DESCRIPTION
### Description

`curl_close` has no effect since PHP 8.0 and is deprecated since 8.5

https://www.php.net/curl_close

This patch prevents warnings on PHP 8.5

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
