### PR TITLE
Avoid PHP 8.5 deprecation notice when loading the tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This is the Developer Changelog for Matomo PHP Tracker. All breaking changes or new features are listed below.
 
+## Matomo PHP Tracker 4.0.1
+
+### Fixed
+- Loading `MatomoTracker.php` no longer emits a deprecation notice for the predefined `$http_response_header` variable on PHP 8.5. PHP reports it at compile time, so it was emitted on every include (#155).
+
 ## Matomo PHP Tracker 4.0.0
 
 Attention: this is a major release with breaking changes.

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -2400,6 +2400,12 @@ didn't change any existing VisitorId value */
             $stream_options = $this->prepareStreamOptions($method, $data, $forcePostUrlEncoded);
 
             $ctx = stream_context_create($stream_options);
+
+            // $http_response_header must be assigned before the fallback read below: PHP 8.5
+            // deprecated the predefined variable and reports it at compile time, so the read would
+            // otherwise emit a notice merely by loading this file. PHP still overwrites the value.
+            $http_response_header = [];
+
             $response = @file_get_contents($url, false, $ctx);
             if ($response === false && $this->exceptionsEnabled) {
                 // Only include the host (never the query string, which carries token_auth/PII) in the message.
@@ -2414,8 +2420,8 @@ didn't change any existing VisitorId value */
                     $responseHeaders = $headers;
                 }
             } elseif ($response !== false) {
-                // PHP populates $http_response_header in the local scope whenever an HTTP response
-                // was received; the $response !== false guard guarantees that is the case here.
+                // PHP < 8.5 has no http_get_last_response_headers() and populates the local
+                // variable instead, which it only does when a response was actually received.
                 $responseHeaders = $http_response_header;
             }
 

--- a/tests/Unit/MatomoTrackerTest.php
+++ b/tests/Unit/MatomoTrackerTest.php
@@ -546,6 +546,29 @@ class MatomoTrackerTest extends TestCase
         $this->assertFalse($tracker->doTrackPageView('some title'));
     }
 
+    /**
+     * Loading the tracker must not emit any notice, as tools that turn those into exceptions
+     * (e.g. Psalm) would abort while autoloading the class. This is what the `$http_response_header`
+     * assignment in `sendRequest()` guards, so that assignment must stay above the read following it.
+     */
+    public function testLoadingTheTrackerEmitsNoDeprecationNotice(): void
+    {
+        // -n ignores the environment's php.ini, so that unrelated startup diagnostics (e.g. a
+        // dangling extension line) cannot fail this test
+        $command = escapeshellarg(PHP_BINARY)
+            . ' -n -d error_reporting=-1 -d display_errors=1 -d log_errors=0 -r '
+            . escapeshellarg('include ' . var_export(dirname(__DIR__, 2) . '/MatomoTracker.php', true) . '; echo \'loaded\';')
+            . ' 2>&1';
+
+        $output = [];
+        $exitCode = -1;
+        exec($command, $output, $exitCode);
+
+        // expecting the marker rather than just no output also catches a child that never ran
+        $this->assertSame('loaded', trim(implode("\n", $output)), 'Loading the tracker must not emit any notice');
+        $this->assertSame(0, $exitCode);
+    }
+
     public function testGetUrlTrackCrash(): void
     {
         $tracker = $this->createTracker();


### PR DESCRIPTION
## Problem

PHP 8.5 deprecated the predefined locally scoped `$http_response_header` variable, and reports it **at compile time**. The stream transport's pre-8.5 fallback read therefore made merely loading `MatomoTracker.php` emit a deprecation — even on 8.5, where the branch that actually runs is `http_get_last_response_headers()`:

```
$ php -r "include 'vendor/matomo/matomo-php-tracker/MatomoTracker.php';"
Deprecated: The predefined locally scoped $http_response_header variable is deprecated,
call http_get_last_response_headers() instead in .../MatomoTracker.php on line 2419
```

Because it fires on include rather than on use, it can neither be suppressed with `@` nor avoided by the `function_exists('http_get_last_response_headers')` guard. Tools that turn diagnostics into exceptions abort while autoloading the class — the reporter hit this with Psalm 6.16.1, which crashes evaluating `class_exists('\MatomoTracker')` in `PiwikTracker.php:17` — and applications that log deprecations get one entry per include.

Reported by @Baffos in #155.

## Fix

Assign the variable before the fallback reads it. That silences the compile-time diagnostic while keeping the pre-8.5 fallback working, and is the shape 3.4.0 used. Header handling is otherwise unchanged: `http_get_last_response_headers()` is still preferred whenever it exists.

Alternatives were checked and rejected:

- **A dedicated helper method cannot work** — the engine populates the variable in the frame that called `file_get_contents()`, so a helper reading it sees nothing.
- **`get_defined_vars()['http_response_header'] ?? []` is a trap** — it silences the 8.5 diagnostic but returns nothing on 8.1–8.5 alike (no CV exists), silently breaking incoming `Set-Cookie` parsing on PHP < 8.5.
- **Dropping the fallback** isn't possible while 8.1–8.4 are supported, since the stream transport is the no-cURL path.

Note the fix is order-sensitive: moving the assignment below the read reintroduces the notice (verified — an assignment the compiler has not yet seen does not help). That's what the new test guards.

## Notes

- Verified in `php:8.5-cli`: the deprecation is emitted on `master` and gone with this change. Also verified the pre-assignment does **not** mask real headers — with a sentinel value, PHP replaces it with the real response headers (incl. `Set-Cookie`) on both 8.1 and 8.5, and end-to-end incoming-cookie parsing over the stream transport still works on both.
- Added `testLoadingTheTrackerEmitsNoDeprecationNotice`, which loads the tracker in a clean subprocess and asserts it emits nothing. Confirmed it fails on 8.5 without the fix and passes with it; CI already covers 8.5. It runs with `-n` so an unrelated `php.ini` extension line in a contributor's environment can't turn into a false failure (confirmed both ways).
- `phpunit` (156 tests), `phpstan` (level max) and `phpcs` are clean; the suite passes on 8.1, 8.3 and 8.5.
- Possible follow-up, deliberately left out of this PR: `phpunit.xml.dist` has no `failOn*` flags, and `--fail-on-deprecation` alone would have caught this bug class in-process (verified: it exits 1 on `master` under 8.5). Adding `failOnDeprecation`/`failOnWarning`/`failOnNotice` passes cleanly with this fix, but it changes strictness for the whole suite, so it seemed like your call rather than a drive-by.
